### PR TITLE
Ensure terminal close listeners are disposed

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -61,17 +61,16 @@ function t(key: keyof typeof i18n.en, ...args: string[]): string {
 export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand("doping.openMenu", openMenu),
-    vscode.commands.registerCommand("doping.stopAll", stopAll)
-  );
-
-  vscode.window.onDidCloseTerminal((t) => {
-    for (const [key, rec] of terminals) {
-      if (rec.terminal === t) {
-        terminals.delete(key);
+    vscode.commands.registerCommand("doping.stopAll", stopAll),
+    vscode.window.onDidCloseTerminal((t) => {
+      for (const [key, rec] of terminals) {
+        if (rec.terminal === t) {
+          terminals.delete(key);
+        }
       }
-    }
-    refreshRunningContext();
-  });
+      refreshRunningContext();
+    })
+  );
 }
 
 export function deactivate() {}


### PR DESCRIPTION
## Summary
- clean up `onDidCloseTerminal` listener to prevent leaks

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68abfc94f0e0832585b403f0387999ac